### PR TITLE
mortred: use `Qtility.Data.Types` time types

### DIFF
--- a/mortred/src/Mortred/Indeed.hs
+++ b/mortred/src/Mortred/Indeed.hs
@@ -4,6 +4,7 @@ module Mortred.Indeed where
 import Mortred.Session
 import Mortred.Types
 import Qtility.Data (fromMaybeM)
+import Qtility.Data.Types (Milliseconds (..))
 import RIO
 import qualified RIO.List as List
 import qualified RIO.Text as Text

--- a/mortred/src/Mortred/Session.hs
+++ b/mortred/src/Mortred/Session.hs
@@ -21,6 +21,7 @@ import Mortred.Types.Errors
 import Mortred.Xvfb
 import Network.HTTP.Client (HttpException)
 import Qtility
+import Qtility.Data.Types (Milliseconds (..))
 import System.Process.Typed (stopProcess)
 import Test.WebDriver (Browser (..), WD, WDConfig (..), defaultConfig, runSession, useBrowser)
 
@@ -119,7 +120,7 @@ startSessions (PortNumber startPortNumber) count seleniumPath = do
 waitRunSession ::
   forall m a.
   (MonadThrow m, MonadUnliftIO m) =>
-  Milliseconds ->
+  Milliseconds Int ->
   WDConfig ->
   WD a ->
   m a

--- a/mortred/src/Mortred/Types.hs
+++ b/mortred/src/Mortred/Types.hs
@@ -4,6 +4,7 @@
 module Mortred.Types where
 
 import Control.Lens.TH (makeLenses, makeWrapped)
+import Qtility.Data.Types (Milliseconds)
 import RIO
 import System.Process.Typed (Process)
 
@@ -25,9 +26,6 @@ newtype Url = Url {_unUrl :: String}
   deriving (Eq, Show, Generic)
 
 newtype MajorVersion = MajorVersion {_unMajorVersion :: Int}
-  deriving (Eq, Show, Generic)
-
-newtype Milliseconds = Milliseconds {_unMilliseconds :: Int}
   deriving (Eq, Show, Generic)
 
 newtype ChromeVersion = ChromeVersion {_unChromeVersion :: MajorVersion}
@@ -80,7 +78,6 @@ foldMapM
     ''PortNumber,
     ''Url,
     ''MajorVersion,
-    ''Milliseconds,
     ''ChromeVersion,
     ''ChromeDriverVersion
   ]

--- a/mortred/src/Mortred/Types/Errors.hs
+++ b/mortred/src/Mortred/Types/Errors.hs
@@ -6,6 +6,7 @@ import Data.Conduit.Serialization.Binary (ParseError)
 import Mortred.Types
 import Network.HTTP.Client (HttpException (..))
 import Qtility
+import Qtility.Data.Types (Milliseconds)
 import Qtility.TH.Optics (makeClassyException)
 
 data XvfbStartError
@@ -66,7 +67,7 @@ data SeleniumStartError
 data SessionRunTimedOut = SessionRunTimedOut
   { _srtoPort :: Int,
     _srtoHost :: String,
-    _srtoMilliseconds :: Milliseconds
+    _srtoMilliseconds :: Milliseconds Int
   }
   deriving (Show)
 

--- a/qtility/src/Qtility/Data/Types.hs
+++ b/qtility/src/Qtility/Data/Types.hs
@@ -2,7 +2,7 @@
 
 module Qtility.Data.Types where
 
-import Control.Lens.TH (makeLenses)
+import Control.Lens.TH (makeLenses, makeWrapped)
 import RIO
 
 newtype Seconds a = Seconds {_unSeconds :: a}
@@ -15,3 +15,5 @@ newtype Microseconds a = Microseconds {_unMicroseconds :: a}
   deriving (Eq, Show)
 
 foldMapM makeLenses [''Seconds, ''Milliseconds, ''Microseconds]
+
+foldMapM makeWrapped [''Seconds, ''Milliseconds, ''Microseconds]


### PR DESCRIPTION
`mortred` was previously using its own `Milliseconds` type.