### PR TITLE
feat: add `deriveAbbreviatedJSON`

### DIFF
--- a/qtility/src/Qtility/TH.hs
+++ b/qtility/src/Qtility/TH.hs
@@ -2,7 +2,7 @@ module Qtility.TH where
 
 import Control.Lens.TH (makeClassy, makeLenses)
 import Language.Haskell.TH
-import Qtility.TH.JSON (deriveJSON, deriveJSON')
+import Qtility.TH.JSON (deriveAbbreviatedJSON, deriveJSON, deriveJSON')
 import RIO
 
 -- | Derives both lens definitions as well as both 'ToJSON' and 'FromJSON'. The type is assumed to
@@ -26,6 +26,22 @@ deriveLensAndJSON' :: Name -> Name -> Q [Dec]
 deriveLensAndJSON' optionsName name = do
   lenses <- makeLenses name
   (lenses <>) <$> deriveJSON' optionsName name
+
+-- | Like 'deriveLensAndJSON' but specialized for types with abbreviated lens prefixes. For example:
+--
+-- @
+--    data SetOfPossibleValues = SetOfPossibleValues
+--      { _sopvName :: Text,
+--        _sopvValues :: [Text]
+--      }
+--      deriving (Eq, Show, Generic)
+--
+--    deriveAbbreviatedLensAndJSON ''SetOfPossibleValues
+-- @
+deriveLensAndAbbreviatedJSON :: Name -> Q [Dec]
+deriveLensAndAbbreviatedJSON name = do
+  lenses <- makeLenses name
+  (lenses <>) <$> deriveAbbreviatedJSON name
 
 -- | Derives both classy lens definitions as well as both 'ToJSON' and 'FromJSON'. The type is
 -- assumed to follow the format that 'deriveJSON' requires, where all fields are prefixed with an

--- a/qtility/src/Qtility/TH.hs
+++ b/qtility/src/Qtility/TH.hs
@@ -38,6 +38,9 @@ deriveLensAndJSON' optionsName name = do
 --
 --    deriveAbbreviatedLensAndJSON ''SetOfPossibleValues
 -- @
+--
+-- This will generate the appropriate lenses and also make sure that your 'ToJSON' and 'FromJSON'
+-- instances are correctly created with field label modifiers that remove the `_sopv` prefix.
 deriveLensAndAbbreviatedJSON :: Name -> Q [Dec]
 deriveLensAndAbbreviatedJSON name = do
   lenses <- makeLenses name

--- a/qtility/src/Qtility/TH/JSON.hs
+++ b/qtility/src/Qtility/TH/JSON.hs
@@ -76,6 +76,9 @@ deriveJSON' optionsName name = do
 --   data SetOfPossibleValues = SetOfPossibleValues {_sopvName :: String, _sopvValues :: [String]}
 --     deriving (Eq, Show, Generic)
 -- @
+--
+-- This will make sure that your 'ToJSON' and 'FromJSON' instances are correctly created with
+-- field label modifiers that remove only the abbreviation, i.e. `_sopv` in this example.
 deriveAbbreviatedJSON :: Name -> Q [Dec]
 deriveAbbreviatedJSON name = do
   [d|

--- a/qtility/src/Qtility/TH/JSON.hs
+++ b/qtility/src/Qtility/TH/JSON.hs
@@ -9,6 +9,8 @@ module Qtility.TH.JSON
     prefixedLensOptions,
     camelToSnake,
     lowerCaseFirstCharacter,
+    prefixedAbbreviatedLensOptions,
+    deriveAbbreviatedJSON,
   )
 where
 
@@ -30,6 +32,12 @@ import qualified RIO.Char as Char
 prefixedLensOptions :: String -> (String -> String) -> Options
 prefixedLensOptions name f =
   let fieldLabelModifier = drop (length name + 1) >>> lowerCaseFirstCharacter >>> f
+   in defaultOptions {fieldLabelModifier}
+
+prefixedAbbreviatedLensOptions :: String -> (String -> String) -> Options
+prefixedAbbreviatedLensOptions name f =
+  let nameAbbreviationLength = name & filter Char.isUpper & length
+      fieldLabelModifier = drop (nameAbbreviationLength + 1) >>> lowerCaseFirstCharacter >>> f
    in defaultOptions {fieldLabelModifier}
 
 -- | Generates standard 'ToJSON' and 'FromJSON' instances based on the format that the fields in a
@@ -59,6 +67,23 @@ deriveJSON' optionsName name = do
 
     instance ToJSON $(conT name) where
       toJSON = genericToJSON $ $(varE optionsName) $(lift $ nameBase name)
+    |]
+
+-- | Generates standard 'ToJSON' and 'FromJSON' instances for fields that are using lensed prefixes
+-- with abbreviation for the type name. An example would be a type called @SetOfPossibleValues@:
+--
+-- @
+--   data SetOfPossibleValues = SetOfPossibleValues {_sopvName :: String, _sopvValues :: [String]}
+--     deriving (Eq, Show, Generic)
+-- @
+deriveAbbreviatedJSON :: Name -> Q [Dec]
+deriveAbbreviatedJSON name = do
+  [d|
+    instance FromJSON $(conT name) where
+      parseJSON = genericParseJSON $ prefixedAbbreviatedLensOptions $(lift $ nameBase name) id
+
+    instance ToJSON $(conT name) where
+      toJSON = genericToJSON $ prefixedAbbreviatedLensOptions $(lift $ nameBase name) id
     |]
 
 -- | Takes several names and generates standard 'ToJSON' and 'FromJSON' instances for each of them.


### PR DESCRIPTION
Should be used when we are using abbreviated lens prefixes:

```haskell
data SetOfPossibleValues = SetOfPossibleValues
  { _sopvName :: Text,
    _sopvValues :: [Text]
  }
  deriving (Eq, Show, Generic)

deriveAbbreviatedJSON ''SetOfPossibleValues
```