### PR TITLE
feat(qtility): add `FileSystem` classes

### DIFF
--- a/qtility-db/src/Qtility/Database/Migration.hs
+++ b/qtility-db/src/Qtility/Database/Migration.hs
@@ -4,7 +4,7 @@ import Qtility
 import Qtility.Database
 import Qtility.Database.Migration.Queries
 import Qtility.Database.Types
-import Qtility.FileSystem (FileSystemRead (..))
+import Qtility.FileSystem (ReadFileSystem (..))
 import RIO.FilePath (takeBaseName, takeExtension, (</>))
 import qualified RIO.List.Partial as PartialList
 import qualified RIO.Text as Text
@@ -13,7 +13,7 @@ import RIO.Time (UTCTime)
 import qualified RIO.Time as Time
 
 createMigrationTable ::
-  (MonadIO m, MonadThrow m, MonadReader env m, FileSystemRead m, HasPostgresqlPool env) =>
+  (MonadIO m, MonadThrow m, MonadReader env m, ReadFileSystem m, HasPostgresqlPool env) =>
   Maybe DatabaseSchema ->
   FilePath ->
   m [Migration]
@@ -26,7 +26,7 @@ createMigrationTable maybeSchema migrationsPath = do
 
   pure migrations
 
-migrationsInDirectory :: (FileSystemRead m, MonadThrow m) => FilePath -> m [Migration]
+migrationsInDirectory :: (ReadFileSystem m, MonadThrow m) => FilePath -> m [Migration]
 migrationsInDirectory path = do
   migrationFilenames <- filter (takeExtension >>> (== ".sql")) <$> listDirectoryM path
   forM migrationFilenames $ \filename -> do

--- a/qtility-db/src/Qtility/Database/Migration.hs
+++ b/qtility-db/src/Qtility/Database/Migration.hs
@@ -4,7 +4,7 @@ import Qtility
 import Qtility.Database
 import Qtility.Database.Migration.Queries
 import Qtility.Database.Types
-import RIO.Directory (listDirectory)
+import Qtility.FileSystem (FileSystemRead (..))
 import RIO.FilePath (takeBaseName, takeExtension, (</>))
 import qualified RIO.List.Partial as PartialList
 import qualified RIO.Text as Text
@@ -13,7 +13,7 @@ import RIO.Time (UTCTime)
 import qualified RIO.Time as Time
 
 createMigrationTable ::
-  (MonadIO m, MonadThrow m, MonadReader env m, HasPostgresqlPool env) =>
+  (MonadIO m, MonadThrow m, MonadReader env m, FileSystemRead m, HasPostgresqlPool env) =>
   Maybe DatabaseSchema ->
   FilePath ->
   m [Migration]
@@ -26,15 +26,12 @@ createMigrationTable maybeSchema migrationsPath = do
 
   pure migrations
 
-migrationsInDirectory ::
-  (MonadIO m, MonadThrow m) =>
-  FilePath ->
-  m [Migration]
+migrationsInDirectory :: (FileSystemRead m, MonadThrow m) => FilePath -> m [Migration]
 migrationsInDirectory path = do
-  migrationFilenames <- filter (takeExtension >>> (== ".sql")) <$> liftIO (listDirectory path)
+  migrationFilenames <- filter (takeExtension >>> (== ".sql")) <$> listDirectoryM path
   forM migrationFilenames $ \filename -> do
     timestamp <- parseMigrationTimestamp filename
-    migrationText <- liftIO $ readFileUtf8 $ path </> filename
+    migrationText <- readFileM $ path </> filename
     (up, down) <- parseMigrationText filename migrationText
 
     pure $

--- a/qtility/qtility.cabal
+++ b/qtility/qtility.cabal
@@ -22,6 +22,7 @@ library
       Qtility.Exceptions
       Qtility.File
       Qtility.File.Types
+      Qtility.FileSystem
       Qtility.TH
       Qtility.TH.JSON
       Qtility.TH.OpenApi

--- a/qtility/src/Qtility/FileSystem.hs
+++ b/qtility/src/Qtility/FileSystem.hs
@@ -1,7 +1,7 @@
 module Qtility.FileSystem
   ( FileSystem,
-    FileSystemWrite (..),
-    FileSystemRead (..),
+    WriteFileSystem (..),
+    ReadFileSystem (..),
   )
 where
 
@@ -15,30 +15,30 @@ import RIO.Directory
     removeFile,
   )
 
-class (FileSystemRead m, FileSystemWrite m) => FileSystem m
+class (ReadFileSystem m, WriteFileSystem m) => FileSystem m
 
-class (Monad m) => FileSystemWrite m where
+class (Monad m) => WriteFileSystem m where
   writeFileM :: FilePath -> Text -> m ()
   writeByteStringFileM :: FilePath -> ByteString -> m ()
   makeDirectoryM :: Bool -> FilePath -> m ()
   removeFileM :: FilePath -> m ()
   removeDirectoryM :: FilePath -> m ()
 
-instance FileSystemWrite IO where
+instance WriteFileSystem IO where
   writeFileM = writeFileUtf8
   writeByteStringFileM = writeFileBinary
   makeDirectoryM = createDirectoryIfMissing
   removeFileM = removeFile
   removeDirectoryM = removeDirectoryRecursive
 
-class (Monad m) => FileSystemRead m where
+class (Monad m) => ReadFileSystem m where
   readFileM :: FilePath -> m Text
   readByteStringFileM :: FilePath -> m ByteString
   listDirectoryM :: FilePath -> m [FilePath]
   doesFileExistM :: FilePath -> m Bool
   doesDirectoryExistM :: FilePath -> m Bool
 
-instance FileSystemRead IO where
+instance ReadFileSystem IO where
   readFileM = readFileUtf8
   readByteStringFileM = readFileBinary
   listDirectoryM = listDirectory

--- a/qtility/src/Qtility/FileSystem.hs
+++ b/qtility/src/Qtility/FileSystem.hs
@@ -1,0 +1,46 @@
+module Qtility.FileSystem
+  ( FileSystem,
+    FileSystemWrite (..),
+    FileSystemRead (..),
+  )
+where
+
+import RIO
+import RIO.Directory
+  ( createDirectoryIfMissing,
+    doesDirectoryExist,
+    doesFileExist,
+    listDirectory,
+    removeDirectoryRecursive,
+    removeFile,
+  )
+
+class (FileSystemRead m, FileSystemWrite m) => FileSystem m
+
+class (Monad m) => FileSystemWrite m where
+  writeFileM :: FilePath -> Text -> m ()
+  writeByteStringFileM :: FilePath -> ByteString -> m ()
+  makeDirectoryM :: Bool -> FilePath -> m ()
+  removeFileM :: FilePath -> m ()
+  removeDirectoryM :: FilePath -> m ()
+
+instance FileSystemWrite IO where
+  writeFileM = writeFileUtf8
+  writeByteStringFileM = writeFileBinary
+  makeDirectoryM = createDirectoryIfMissing
+  removeFileM = removeFile
+  removeDirectoryM = removeDirectoryRecursive
+
+class (Monad m) => FileSystemRead m where
+  readFileM :: FilePath -> m Text
+  readByteStringFileM :: FilePath -> m ByteString
+  listDirectoryM :: FilePath -> m [FilePath]
+  doesFileExistM :: FilePath -> m Bool
+  doesDirectoryExistM :: FilePath -> m Bool
+
+instance FileSystemRead IO where
+  readFileM = readFileUtf8
+  readByteStringFileM = readFileBinary
+  listDirectoryM = listDirectory
+  doesFileExistM = doesFileExist
+  doesDirectoryExistM = doesDirectoryExist


### PR DESCRIPTION
In `Qtility.FileSystem`:

Contains a class describing operations that read from the file system as well as one that writes to the file system. The idea is that these will be easier to mock and use and more descriptive when using type classes to describe effects.