### PR TITLE
fix(qtility-db): sort in `migrationsInDirectory`

### DIFF
--- a/qtility-db/src/Qtility/Database/Migration.hs
+++ b/qtility-db/src/Qtility/Database/Migration.hs
@@ -6,6 +6,7 @@ import Qtility.Database.Migration.Queries
 import Qtility.Database.Types
 import Qtility.FileSystem (ReadFileSystem (..))
 import RIO.FilePath (takeBaseName, takeExtension, (</>))
+import qualified RIO.List as List
 import qualified RIO.List.Partial as PartialList
 import qualified RIO.Text as Text
 import qualified RIO.Text.Partial as PartialText
@@ -28,7 +29,8 @@ createMigrationTable maybeSchema migrationsPath = do
 
 migrationsInDirectory :: (ReadFileSystem m, MonadThrow m) => FilePath -> m [Migration]
 migrationsInDirectory path = do
-  migrationFilenames <- filter (takeExtension >>> (== ".sql")) <$> listDirectoryM path
+  migrationFilenames <-
+    (filter (takeExtension >>> (== ".sql")) >>> List.sort) <$> listDirectoryM path
   forM migrationFilenames $ \filename -> do
     timestamp <- parseMigrationTimestamp filename
     migrationText <- readFileM $ path </> filename

--- a/qtility-db/test/MigrationSpec.hs
+++ b/qtility-db/test/MigrationSpec.hs
@@ -12,6 +12,7 @@ import Qtility.Database.Migration.Queries
 import Qtility.Database.Queries (doesTableExist)
 import Qtility.Database.Testing (createTemporaryDatabaseConnectionPool)
 import Qtility.Database.Types
+import qualified RIO.List as List
 import Test.Hspec
 
 newtype UnableToStartTemporaryPostgres = UnableToStartTemporaryPostgres String
@@ -81,7 +82,8 @@ spec = do
           )
           `shouldReturn` (True, False)
 
-        _ <- runTestMonad state $ createMigrationTable Nothing "test/test-data/migrations2"
+        migrations2 <- runTestMonad state $ createMigrationTable Nothing "test/test-data/migrations2"
+        migrations2 `shouldBe` List.sortBy (comparing (^. migrationFilename)) migrations2
         newMigrations <- runTestMonad state $ runDB $ getMigrations Nothing
         newMigrations `shouldNotBe` migrations
         length migrations `shouldBe` 1


### PR DESCRIPTION
This previously would return a jumble of results in terms of filenames.